### PR TITLE
Add support for acronyms

### DIFF
--- a/lib/recase.dart
+++ b/lib/recase.dart
@@ -1,6 +1,7 @@
 /// An instance of text to be re-cased.
 class ReCase {
   final RegExp _upperAlphaRegex = new RegExp(r'[A-Z]');
+  final RegExp _lowerAlphaRegex = new RegExp(r'[a-z]');
   final RegExp _symbolRegex = new RegExp(r'[ ./_\-]');
 
   String originalText;
@@ -21,16 +22,19 @@ class ReCase {
       String nextChar = (i + 1 == text.length
           ? null
           : new String.fromCharCode(text.codeUnitAt(i + 1)));
-
+      String nextNextChar = (i + 2 >= text.length
+          ? null
+          : new String.fromCharCode(text.codeUnitAt(i + 2)));
       if (_symbolRegex.hasMatch(char)) {
         continue;
       }
 
       sb.write(char);
 
-      bool isEndOfWord = nextChar == null ||
-          (_upperAlphaRegex.hasMatch(nextChar) && !isAllCaps) ||
-          _symbolRegex.hasMatch(nextChar);
+      bool isEndOfWord = nextChar == null
+          || (_upperAlphaRegex.hasMatch(nextChar) && !_upperAlphaRegex.hasMatch(char) && !isAllCaps)
+          || (_upperAlphaRegex.hasMatch(char) && _upperAlphaRegex.hasMatch(nextChar) && nextNextChar != null && _lowerAlphaRegex.hasMatch(nextNextChar))
+          || _symbolRegex.hasMatch(nextChar);
 
       if (isEndOfWord) {
         words.add(sb.toString());
@@ -104,6 +108,11 @@ class ReCase {
   }
 
   String _upperCaseFirstLetter(String word) {
-    return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+    if (word.length == 2 && word.toLowerCase() != 'id') {
+      return '${word.substring(0, 1).toUpperCase()}${word.substring(1)}';
+    } else {
+      return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+    }
+
   }
 }

--- a/lib/recase.dart
+++ b/lib/recase.dart
@@ -31,10 +31,15 @@ class ReCase {
 
       sb.write(char);
 
-      bool isEndOfWord = nextChar == null
-          || (_upperAlphaRegex.hasMatch(nextChar) && !_upperAlphaRegex.hasMatch(char) && !isAllCaps)
-          || (_upperAlphaRegex.hasMatch(char) && _upperAlphaRegex.hasMatch(nextChar) && nextNextChar != null && _lowerAlphaRegex.hasMatch(nextNextChar))
-          || _symbolRegex.hasMatch(nextChar);
+      bool isEndOfWord = nextChar == null ||
+          (_upperAlphaRegex.hasMatch(nextChar) &&
+              !_upperAlphaRegex.hasMatch(char) &&
+              !isAllCaps) ||
+          (_upperAlphaRegex.hasMatch(char) &&
+              _upperAlphaRegex.hasMatch(nextChar) &&
+              nextNextChar != null &&
+              _lowerAlphaRegex.hasMatch(nextNextChar)) ||
+          _symbolRegex.hasMatch(nextChar);
 
       if (isEndOfWord) {
         words.add(sb.toString());
@@ -113,6 +118,5 @@ class ReCase {
     } else {
       return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
     }
-
   }
 }

--- a/test/recase_test.dart
+++ b/test/recase_test.dart
@@ -5,6 +5,7 @@ import 'package:recase/recase.dart';
 void main() {
   ReCase rcInput = new ReCase('This is-Some_sampleText. YouDig?');
   ReCase allCapsInput = new ReCase('FOO_BAR');
+  ReCase acronynInput = new ReCase('My HTTP DBConnection-Info ID XML');
 
   group('snake_case', () {
     test('from "${rcInput.originalText}".', () {
@@ -14,6 +15,11 @@ void main() {
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.snakeCase, equals('foo_bar'));
     });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.snakeCase, equals('my_http_db_connection_info_id_xml'));
+    });
+
   });
 
   group('dot.case', () {
@@ -23,6 +29,10 @@ void main() {
 
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.dotCase, equals('foo.bar'));
+    });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.dotCase, equals('my.http.db.connection.info.id.xml'));
     });
   });
 
@@ -34,6 +44,10 @@ void main() {
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.pathCase, equals('foo/bar'));
     });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.pathCase, equals('my/http/db/connection/info/id/xml'));
+    });
   });
 
   group('param-case', () {
@@ -43,6 +57,10 @@ void main() {
 
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.paramCase, equals('foo-bar'));
+    });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.paramCase, equals('my-http-db-connection-info-id-xml'));
     });
   });
 
@@ -54,6 +72,10 @@ void main() {
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.pascalCase, equals('FooBar'));
     });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.pascalCase, equals('MyHttpDBConnectionInfoIdXml'));
+    });
   });
 
   group('Header-Case', () {
@@ -63,6 +85,10 @@ void main() {
 
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.headerCase, equals('Foo-Bar'));
+    });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.headerCase, equals('My-Http-DB-Connection-Info-Id-Xml'));
     });
   });
 
@@ -74,6 +100,10 @@ void main() {
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.titleCase, equals('Foo Bar'));
     });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.titleCase, equals('My Http DB Connection Info Id Xml'));
+    });
   });
 
   group('camelCase', () {
@@ -83,6 +113,10 @@ void main() {
 
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.camelCase, equals('fooBar'));
+    });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.camelCase, equals('myHttpDBConnectionInfoIdXml'));
     });
   });
 
@@ -94,6 +128,10 @@ void main() {
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.sentenceCase, equals('Foo bar'));
     });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.sentenceCase, equals('My http db connection info id xml'));
+    });
   });
 
   group('CONSTANT_CASE', () {
@@ -103,6 +141,10 @@ void main() {
 
     test('from "${allCapsInput.originalText}".', () {
       expect(allCapsInput.constantCase, equals('FOO_BAR'));
+    });
+
+    test('from "${acronynInput.originalText}".', () {
+      expect(acronynInput.constantCase, equals('MY_HTTP_DB_CONNECTION_INFO_ID_XML'));
     });
   });
 }

--- a/test/recase_test.dart
+++ b/test/recase_test.dart
@@ -17,9 +17,9 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.snakeCase, equals('my_http_db_connection_info_id_xml'));
+      expect(
+          acronynInput.snakeCase, equals('my_http_db_connection_info_id_xml'));
     });
-
   });
 
   group('dot.case', () {
@@ -46,7 +46,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.pathCase, equals('my/http/db/connection/info/id/xml'));
+      expect(
+          acronynInput.pathCase, equals('my/http/db/connection/info/id/xml'));
     });
   });
 
@@ -60,7 +61,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.paramCase, equals('my-http-db-connection-info-id-xml'));
+      expect(
+          acronynInput.paramCase, equals('my-http-db-connection-info-id-xml'));
     });
   });
 
@@ -88,7 +90,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.headerCase, equals('My-Http-DB-Connection-Info-Id-Xml'));
+      expect(
+          acronynInput.headerCase, equals('My-Http-DB-Connection-Info-Id-Xml'));
     });
   });
 
@@ -102,7 +105,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.titleCase, equals('My Http DB Connection Info Id Xml'));
+      expect(
+          acronynInput.titleCase, equals('My Http DB Connection Info Id Xml'));
     });
   });
 
@@ -130,7 +134,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.sentenceCase, equals('My http db connection info id xml'));
+      expect(acronynInput.sentenceCase,
+          equals('My http db connection info id xml'));
     });
   });
 
@@ -144,7 +149,8 @@ void main() {
     });
 
     test('from "${acronynInput.originalText}".', () {
-      expect(acronynInput.constantCase, equals('MY_HTTP_DB_CONNECTION_INFO_ID_XML'));
+      expect(acronynInput.constantCase,
+          equals('MY_HTTP_DB_CONNECTION_INFO_ID_XML'));
     });
   });
 }


### PR DESCRIPTION
This adds support for acronyms in the input text and the (usually) correct behavior when converting to camel or pascal case, according to the effect dart guide: 

https://www.dartlang.org/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words

This isn't 100% fool proof since there is no way to programmatically tell if a two-letter word is an acronym (e.g. "DB" for "database"), which should remain capitalized, or an abbreviation (e.g. "Id" for "identification"), which should only have the first letter capitalized.  The behavior in this PR is to assume it's an acronym, with a hard-coded check for "Id" on the assumption that that will be used frequently.

(This is some functionality I needed for a project I'm working on and I am totally open to suggestions for changes and improvements on this PR.)