### PR TITLE
Colon case

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Supports:
 * dot.case
 * path/case
 * param-case
+* colon:case
 * PascalCase
 * Header-Case
 * Title Case

--- a/lib/recase.dart
+++ b/lib/recase.dart
@@ -65,6 +65,9 @@ class ReCase {
   /// colon:case
   String get colonCase => _getSnakeCase(separator: ':');
 
+   /// double::colon::case
+  String get doubleColonCase => _getSnakeCase(separator: '::');
+
   /// PascalCase
   String get pascalCase => _getPascalCase();
 
@@ -128,6 +131,8 @@ extension StringReCase on String {
   String get pathCase => ReCase(this).pathCase;
 
   String get colonCase => ReCase(this).colonCase;
+
+  String get doubleColonCase => ReCase(this).doubleColonCase;
 
   String get pascalCase => ReCase(this).pascalCase;
 

--- a/lib/recase.dart
+++ b/lib/recase.dart
@@ -1,7 +1,7 @@
 /// An instance of text to be re-cased.
 class ReCase {
   final RegExp _upperAlphaRegex = new RegExp(r'[A-Z]');
-  final RegExp _symbolRegex = new RegExp(r'[ ./_\-]');
+  final RegExp _symbolRegex = new RegExp(r'[ ./_\-:]');
 
   String originalText;
   List<String> _words;
@@ -61,6 +61,9 @@ class ReCase {
 
   /// path/case
   String get pathCase => _getSnakeCase(separator: '/');
+
+  /// colon:case
+  String get colonCase => _getSnakeCase(separator: ':');
 
   /// PascalCase
   String get pascalCase => _getPascalCase();
@@ -123,6 +126,8 @@ extension StringReCase on String {
   String get paramCase => ReCase(this).paramCase;
 
   String get pathCase => ReCase(this).pathCase;
+
+  String get colonCase => ReCase(this).colonCase;
 
   String get pascalCase => ReCase(this).pascalCase;
 

--- a/test/recase_test.dart
+++ b/test/recase_test.dart
@@ -77,6 +77,26 @@ void main() {
     });
   });
 
+  group('double::colon::case', () {
+    test('from "${rcInput.originalText}".', () {
+      expect(rcInput.doubleColonCase, equals('this::is::some::sample::text::you::dig?'));
+    });
+
+    test('from "${allCapsInput.originalText}".', () {
+      expect(allCapsInput.doubleColonCase, equals('foo::bar'));
+    });
+
+    test('from "${mockText}", using String extension.', () {
+      expect(mockText.doubleColonCase,
+          equals('this::is::some::sample::text::you::dig?'));
+    });
+
+    test('To "double colon extension", using String extension.', () {
+      expect(ReCase('double::colon::extension').sentenceCase,
+          equals('Double colon extension'));
+    });
+  });
+
   group('PascalCase', () {
     test('from "${rcInput.originalText}".', () {
       expect(rcInput.pascalCase, equals('ThisIsSomeSampleTextYouDig?'));

--- a/test/recase_test.dart
+++ b/test/recase_test.dart
@@ -63,6 +63,20 @@ void main() {
     });
   });
 
+  group('colon:case', () {
+    test('from "${rcInput.originalText}".', () {
+      expect(rcInput.colonCase, equals('this:is:some:sample:text:you:dig?'));
+    });
+
+    test('from "${allCapsInput.originalText}".', () {
+      expect(allCapsInput.colonCase, equals('foo:bar'));
+    });
+
+    test('from "${mockText}", using String extension.', () {
+      expect(mockText.colonCase, equals('this:is:some:sample:text:you:dig?'));
+    });
+  });
+
   group('PascalCase', () {
     test('from "${rcInput.originalText}".', () {
       expect(rcInput.pascalCase, equals('ThisIsSomeSampleTextYouDig?'));


### PR DESCRIPTION
This PR  adds colon:case and double::colon::case

This case is used in different languages:

```c++
int A::i = 4;
```

```css
input:focus {
  background-color: yellow;
}
```

```css
h1::after {
  content: url(smiley.gif);
}
```