### PR TITLE
Use equals for default values

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+# Lint rules and documentation, see http://dart-lang.github.io/linter/lints
+linter:
+  rules:
+    - prefer_equal_for_default_values
+

--- a/lib/recase.dart
+++ b/lib/recase.dart
@@ -70,7 +70,7 @@ class ReCase {
   /// Title Case
   String get titleCase => _getPascalCase(separator: ' ');
 
-  String _getCamelCase({String separator: ''}) {
+  String _getCamelCase({String separator = ''}) {
     List<String> words = this._words.map(_upperCaseFirstLetter).toList();
     if (_words.isNotEmpty) {
       words[0] = words[0].toLowerCase();
@@ -79,19 +79,19 @@ class ReCase {
     return words.join(separator);
   }
 
-  String _getConstantCase({String separator: '_'}) {
+  String _getConstantCase({String separator = '_'}) {
     List<String> words = this._words.map((word) => word.toUpperCase()).toList();
 
     return words.join(separator);
   }
 
-  String _getPascalCase({String separator: ''}) {
+  String _getPascalCase({String separator = ''}) {
     List<String> words = this._words.map(_upperCaseFirstLetter).toList();
 
     return words.join(separator);
   }
 
-  String _getSentenceCase({String separator: ' '}) {
+  String _getSentenceCase({String separator = ' '}) {
     List<String> words = this._words.map((word) => word.toLowerCase()).toList();
     if (_words.isNotEmpty) {
       words[0] = _upperCaseFirstLetter(words[0]);
@@ -100,7 +100,7 @@ class ReCase {
     return words.join(separator);
   }
 
-  String _getSnakeCase({String separator: '_'}) {
+  String _getSnakeCase({String separator = '_'}) {
     List<String> words = this._words.map((word) => word.toLowerCase()).toList();
 
     return words.join(separator);


### PR DESCRIPTION
Refactor use `=` for assigning default values. Code currently uses `:` which is an older style of Dart code, which may get deprecated: https://github.com/dart-lang/language/issues/2357